### PR TITLE
Supporting ES6 and ES7 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ List and jump to line in the current spec file.
 ## TODO
 
 * Support CoffeeScript
-* Support ES6
+* ~~Support ES6~~
 * Support RSpec
 * Serialize/Deserialize state
 * Add Settings

--- a/lib/parser.coffee
+++ b/lib/parser.coffee
@@ -2,9 +2,14 @@ esprima = require 'esprima'
 estraverse = require 'estraverse'
 
 types = ['describe', 'context', 'it']
+parserOptions = {
+  loc: true,
+  sourceType: 'module',
+  tolerant: true
+}
 
 module.exports.parse = (source) ->
-  return traverse(esprima.parse(source, { loc: true }))
+  return traverse(esprima.parse(source, parserOptions))
 
 isTarget = (node) ->
   node.type == 'CallExpression' && types.indexOf(node.callee.name) != -1;

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.4",
-    "esprima": "^2.1.0",
-    "estraverse": "^3.1.0",
-    "event-kit": "^1.0.3"
+    "esprima": "^4.0.0",
+    "estraverse": "^4.2.0",
+    "event-kit": "^2.3.0"
   },
   "devDependencies": {
-    "underscore": "^1.8.2"
+    "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
Modern version of esprima supports ES6 and ES7, so I updated dependencies and used the right option for the parser.